### PR TITLE
#6 varying duration test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 ### Added
  - StaggeredMorpher that morphs using a fixed number of steps
+### Changed
+ - Use TestFixtureSources to reduce test duplication
 
 ## [0.0.3] - 7/28/2019
 ### Fixed

--- a/Runtime/Morphers/StaggeredMorpher.cs
+++ b/Runtime/Morphers/StaggeredMorpher.cs
@@ -32,7 +32,6 @@ namespace Morph
             var steps = _intermediateSteps + 2;
             var waitBetweenSteps = new WaitForSeconds(_durationInSeconds / steps);
             var stepSize = 1f / (steps - 1);
-
             for (int i = 0; i < steps; i++)
             {
                 target.Frame(Mathf.Clamp01(Mathf.Abs(directionOffset - i * stepSize)));

--- a/Tests/Runtime/MorpherTests.cs
+++ b/Tests/Runtime/MorpherTests.cs
@@ -1,0 +1,62 @@
+﻿using NUnit.Framework;
+
+namespace Morph.Tests
+{
+    [TestFixtureSource("MorpherFixtureArgs")]
+    public class MorpherTests
+    {
+        private readonly IMorpher _morpher;
+        private MorphSpy _spy { get; set; }
+
+        static object[] MorpherFixtureArgs =
+        {
+            new object[] { new SmoothMorpher(1f), "1s Duration" },
+            new object[] { new SmoothMorpher(0.5f), "0.5s Duration" },
+            new object[] { new SmoothMorpher(2f), "2s Duration" },
+            new object[] { new StaggeredMorpher(1), "1 Intermediate Step" },
+            new object[] { new StaggeredMorpher(3), "3 Intermediate Steps" },
+            new object[] { new StaggeredMorpher(5), "5 Intermediate Steps" }
+        };
+
+        public MorpherTests(IMorpher morpher, string name)
+        {
+            _morpher = morpher;
+        }
+
+        [SetUp]
+        public void InitSpy()
+        {
+            _spy = new MorphSpy();
+        }
+
+        [Test]
+        public void ForwardStartsAtZero()
+        {
+            _morpher.Forwards(_spy).MoveNext();
+            Assert.AreEqual(0, _spy.Time);
+        }
+
+        [Test]
+        public void ForwardEndsAtOne()
+        {
+            var enumerator = _morpher.Forwards(_spy);
+            while (enumerator.MoveNext()) ;
+            Assert.AreEqual(1f, _spy.Time);
+        }
+
+        [Test]
+        public void BackwardsStartsAtOne()
+        {
+            _morpher.Backwards(_spy).MoveNext();
+            Assert.AreEqual(1, _spy.Time);
+        }
+
+        [Test]
+        public void BackwardsEndsAtZero()
+        {
+            var enumerator = _morpher.Backwards(_spy);
+            while (enumerator.MoveNext()) ;
+            Assert.AreEqual(0, _spy.Time);
+        }
+    }
+}

--- a/Tests/Runtime/MorpherTests.cs
+++ b/Tests/Runtime/MorpherTests.cs
@@ -33,7 +33,7 @@ namespace Morph.Tests
         public void ForwardStartsAtZero()
         {
             _morpher.Forwards(_spy).MoveNext();
-            Assert.AreEqual(0, _spy.Time);
+            Assert.AreEqual(0, _spy.Time, 0.001);
         }
 
         [Test]
@@ -41,14 +41,14 @@ namespace Morph.Tests
         {
             var enumerator = _morpher.Forwards(_spy);
             while (enumerator.MoveNext()) ;
-            Assert.AreEqual(1f, _spy.Time);
+            Assert.AreEqual(1f, _spy.Time, 0.001);
         }
 
         [Test]
         public void BackwardsStartsAtOne()
         {
             _morpher.Backwards(_spy).MoveNext();
-            Assert.AreEqual(1, _spy.Time);
+            Assert.AreEqual(1, _spy.Time, 0.001);
         }
 
         [Test]
@@ -56,7 +56,7 @@ namespace Morph.Tests
         {
             var enumerator = _morpher.Backwards(_spy);
             while (enumerator.MoveNext()) ;
-            Assert.AreEqual(0, _spy.Time);
+            Assert.AreEqual(0, _spy.Time, 0.001);
         }
     }
 }

--- a/Tests/Runtime/MorpherTests.cs.meta
+++ b/Tests/Runtime/MorpherTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 27661fe04783ee343aba640186bee23b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime/SmoothMorpherTests.cs
+++ b/Tests/Runtime/SmoothMorpherTests.cs
@@ -5,76 +5,38 @@ using UnityEngine.TestTools;
 
 namespace Morph.Tests
 {
+    [TestFixtureSource("MorpherFixtureArgs")]
     public class SmoothMorpherTests
     {
-        [Test]
-        public void ForwardStartsAtZero ()
+        private readonly IMorpher _morpher;
+        private readonly float _morphDuration;   
+        private MorphSpy _spy { get; set; }
+
+        static object[] MorpherFixtureArgs = 
         {
-            var spy = new MorphSpy();
-            var smoothMorph = new SmoothMorpher();
+            new object[] { new SmoothMorpher(), 1f },
+            new object[] { new SmoothMorpher(0.5f), 0.5f },
+            new object[] { new SmoothMorpher(2f), 2f },
+        };
 
-            smoothMorph.Forwards(spy).MoveNext();
-
-            Assert.AreEqual(0, spy.Time);
+        public SmoothMorpherTests(IMorpher morpher, float morphDuration)
+        {
+            _morpher = morpher;
+            _morphDuration = morphDuration;
         }
 
-        [Test]
-        public void ForwardEndsAtOne ()
+        [SetUp]
+        public void InitSpy ()
         {
-            var spy = new MorphSpy();
-            var smoothMorph = new SmoothMorpher();
-
-            var enumerator = smoothMorph.Forwards(spy);
-            while (enumerator.MoveNext()) ;
-
-            Assert.AreEqual(1f, spy.Time);
-        }
-
-        [Test]
-        public void BackwardsStartsAtOne ()
-        {
-            var spy = new MorphSpy();
-            var smoothMorph = new SmoothMorpher();
-
-            smoothMorph.Backwards(spy).MoveNext();
-
-            Assert.AreEqual(1, spy.Time);
-        }
-
-        [Test]
-        public void BackwardsEndsAtZero ()
-        {
-            var spy = new MorphSpy();
-            var smoothMorph = new SmoothMorpher();
-
-            var enumerator = smoothMorph.Backwards(spy);
-            while (enumerator.MoveNext()) ;
-
-            Assert.AreEqual(0, spy.Time);
+            _spy = new MorphSpy();
         }
 
         [UnityTest]
-        public IEnumerator MorphWithALongDuration ()
+        public IEnumerator MorphRunsForDuration ()
         {
-            var duration = 2f;
-            var morpher = new SmoothMorpher(duration);
             var timeStarted = Time.time;
-
-            yield return morpher.Forwards(new MorphSpy());
-
-            Assert.AreEqual(duration, Time.time - timeStarted, 0.1);
-        }
-
-        [UnityTest]
-        public IEnumerator MorphWithAShortDuration()
-        {
-            var duration = 0.5f;
-            var morpher = new SmoothMorpher(duration);
-            var timeStarted = Time.time;
-
-            yield return morpher.Forwards(new MorphSpy());
-
-            Assert.AreEqual(duration, Time.time - timeStarted, 0.1);
+            yield return _morpher.Forwards(_spy);
+            Assert.AreEqual(_morphDuration, Time.time - timeStarted, 0.1);
         }
     }
 }

--- a/Tests/Runtime/StaggeredMorpherTests.cs
+++ b/Tests/Runtime/StaggeredMorpherTests.cs
@@ -2,102 +2,48 @@
 
 namespace Morph.Tests
 {
+    [TestFixtureSource("MorpherFixtureArgs")]
     public class StaggeredMorpherTests
     {
-        [Test]
-        public void ForwardStartsAtZero ()
+        private readonly IMorpher _morpher;
+        private readonly int _intermediateSteps;
+        private MorphSpy _spy { get; set; }
+
+        static object[] MorpherFixtureArgs =
         {
-            var spy = new MorphSpy();
-            var staggeredMorph = new StaggeredMorpher(0);
+            new object[] { new StaggeredMorpher(1), 1 },
+            new object[] { new StaggeredMorpher(3), 3 },
+            new object[] { new StaggeredMorpher(5), 5 },
+        };
 
-            staggeredMorph.Forwards(spy).MoveNext();
+        public StaggeredMorpherTests (IMorpher morpher, int intermediateSteps)
+        {
+            _morpher = morpher;
+            _intermediateSteps = intermediateSteps;
+        }
 
-            Assert.AreEqual(0, spy.Time);
+        [SetUp]
+        public void InitSpy()
+        {
+            _spy = new MorphSpy();
         }
 
         [Test]
-        public void ForwardEndsAtOne ()
+        public void FramesMatchIntermediateStepCountPlusTwo ()
         {
-            var spy = new MorphSpy();
-            var staggeredMorph = new StaggeredMorpher(0);
-
-            var enumerator = staggeredMorph.Forwards(spy);
+            var enumerator = _morpher.Forwards(_spy);
             while (enumerator.MoveNext()) ;
-
-            Assert.AreEqual(1f, spy.Time);
+            Assert.AreEqual(_intermediateSteps + 2, _spy.FrameCount);
         }
 
         [Test]
-        public void BackwardsStartsAtOne()
+        public void FirstIntermediateFrameHasExpectedTime ()
         {
-            var spy = new MorphSpy();
-            var staggeredMorpher = new StaggeredMorpher(0);
-
-            staggeredMorpher.Backwards(spy).MoveNext();
-
-            Assert.AreEqual(1, spy.Time);
-        }
-
-        [Test]
-        public void BackwardsEndsAtZero()
-        {
-            var spy = new MorphSpy();
-            var staggeredMorpher = new StaggeredMorpher(0);
-
-            var enumerator = staggeredMorpher.Backwards(spy);
-            while (enumerator.MoveNext()) ;
-
-            Assert.AreEqual(0, spy.Time);
-        }
-
-        [Test]
-        public void FramesThreeTimesWithOneIntermediateStep ()
-        {
-            var spy = new MorphSpy();
-            var staggeredMorpher = new StaggeredMorpher(1);
-
-            var enumerator = staggeredMorpher.Forwards(spy);
-            while (enumerator.MoveNext()) ;
-
-            Assert.AreEqual(3, spy.FrameCount);
-        }
-
-        [Test]
-        public void FirstIntermediateFrameIsHalfWithOneIntermediateFrame ()
-        {
-            var spy = new MorphSpy();
-            var staggeredMorpher = new StaggeredMorpher(1);
-
-            var enumerator = staggeredMorpher.Backwards(spy);
+            var enumerator = _morpher.Forwards(_spy);
             enumerator.MoveNext();
             enumerator.MoveNext();
-
-            Assert.AreEqual(0.5f, spy.Time);
-        }
-
-        [Test]
-        public void FramesFourTimesWithTwoIntermediateSteps ()
-        {
-            var spy = new MorphSpy();
-            var staggeredMorpher = new StaggeredMorpher(2);
-
-            var enumerator = staggeredMorpher.Forwards(spy);
-            while (enumerator.MoveNext()) ;
-
-            Assert.AreEqual(4, spy.FrameCount);
-        }
-
-        [Test]
-        public void FirstIntermediateFrameIsAThirdWithTwoIntermediateFrames ()
-        {
-            var spy = new MorphSpy();
-            var staggeredMorpher = new StaggeredMorpher(2);
-
-            var enumerator = staggeredMorpher.Forwards(spy);
-            enumerator.MoveNext();
-            enumerator.MoveNext();
-
-            Assert.AreEqual(0.333f, spy.Time, 0.01);
+            var expectedTime = 1f / (_intermediateSteps + 1);
+            Assert.AreEqual(expectedTime, _spy.Time);
         }
     }
 }


### PR DESCRIPTION
Refactor tests to remove duplicated tests covering varying durations and morpher types, see: [TestFixtureSource](https://github.com/nunit/docs/wiki/TestFixtureSource-Attribute)